### PR TITLE
Clamp digit ROI after cross glyph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # dnc_crane_detection2
+
+## OCR倍率連携の概要
+
+本リポジトリには、YOLOv5ベースの危険検知処理と、倍率表示をOCRで取得する仕組みが含まれています。
+
+- `read_multiplier.py` は、映像内の「×」記号の右隣にある倍率値を高精度に読み取るための専用スクリプトです。固定ROIや自動キャリブレーション、色マスク、テンプレートマッチを組み合わせて、1〜30倍の整数を抽出します。
+- `detect_videos_xoko.py` は、別仮想環境で稼働する `read_magnification_video_complete_fixed.py` をサブプロセス起動し、得られた `ocr_value` を焦点距離に変換してクレーン危険検知ロジックに反映します。
+
+## 代表的な実行例
+
+### 倍率読み取り（ROI手動指定）
+```bash
+python read_multiplier.py --video "/mnt/data/ズーム動画.mp4" --fps 5 --roi 1450 960 130 60 --digit-offset 5 --min-digit-width 60 --save-annotated
+```
+- `--roi` : 「×」記号左上の座標と、右側の数字が収まる幅・高さをピクセルで指定します。
+- `--digit-offset` : 「×」の右端から何ピクセル空けて数字帯域を開始するかを設定します。
+- `--min-digit-width` : 1桁/2桁どちらでも読めるよう最低限確保する帯域幅を指定します。
+- `--save-annotated` : yellow=ROI、orange=数字帯域で描画した画像を `out_frames/` に保存します。
+
+### YOLO推論＋倍率連携
+```bash
+python detect_videos_xoko.py --weights yolov5s.pt --source cam.mp4 \
+    --ocr-python "C:/dnc/AI_env_check/ocr_venv/Scripts/python.exe" \
+    --ocr-script "C:/dnc/AI_env_check/read_magnification_video_complete_fixed.py" \
+    --ocr-extra-args "--summary" --ocr-cache-ttl 5
+```
+- `--ocr-python` : OCR用仮想環境のPython実行ファイル。
+- `--ocr-script` : `ocr_value` を出力するOCRスクリプトパス。
+- `--ocr-cache-ttl` : OCR呼び出し間隔の最小秒数。値をキャッシュしてサブプロセス起動を抑制します。
+- 取得した倍率は `focal_length = 6 + (180-6)*(ocr_value-1)/29` で焦点距離へ換算され、像高推定に利用されます。
+
+## 参照
+- `ocr_system.py` : OCRの設定例や補助関数。
+- `detect_videos_beep.py` : 元になったYOLO推論スクリプト。

--- a/detect_videos_xoko.py
+++ b/detect_videos_xoko.py
@@ -1,0 +1,841 @@
+# YOLOv5 🚀 by Ultralytics, GPL-3.0 license
+"""
+Run inference on images, videos, directories, streams, etc.
+
+This variant (``detect_videos_xoko.py``) extends the standard YOLOv5 runner so
+that it can cooperate with the dedicated OCR environment used to read camera
+magnification overlays.  It launches
+``read_magnification_video_complete_fixed.py`` in a separate virtual
+environment, extracts the reported ``ocr_value`` (1x–30x) and converts it to a
+camera focal length using the linear interpolation ``6mm → 180mm``.  The
+focal length is injected into the crane height estimation routine so zoom
+changes immediately influence danger detection.
+
+Example (Windows paths)::
+
+    python detect_videos_xoko.py --weights yolov5s.pt --source cam.mp4 \
+        --ocr-python "C:/dnc/AI_env_check/ocr_venv/Scripts/python.exe" \
+        --ocr-script "C:/dnc/AI_env_check/read_magnification_video_complete_fixed.py" \
+        --ocr-extra-args "--summary" --ocr-cache-ttl 5
+
+Key OCR options:
+
+``--ocr-python``
+    Path to the Python interpreter inside the OCR virtual environment.
+``--ocr-script``
+    Path to ``read_magnification_video_complete_fixed.py``.
+``--ocr-source``
+    Video fed to the OCR script (defaults to ``--source``).
+``--ocr-extra-args``
+    Extra command line arguments passed verbatim to the OCR script.
+``--ocr-cache-ttl``
+    Minimum seconds between OCR invocations (prevents needless reruns).
+``--ocr-default``
+    Magnification used if the OCR subprocess cannot provide a value.
+
+Usage - sources:
+    $ python path/to/detect.py --weights yolov5s.pt --source 0              # webcam
+                                                             img.jpg        # image
+                                                             vid.mp4        # video
+                                                             path/          # directory
+                                                             path/*.jpg     # glob
+                                                             'https://youtu.be/Zgi9g1ksQHc'  # YouTube
+                                                             'rtsp://example.com/media.mp4'  # RTSP, RTMP, HTTP stream
+
+Usage - formats:
+    $ python path/to/detect.py --weights yolov5s.pt                 # PyTorch
+                                         yolov5s.torchscript        # TorchScript
+                                         yolov5s.onnx               # ONNX Runtime or OpenCV DNN with --dnn
+                                         yolov5s.xml                # OpenVINO
+                                         yolov5s.engine             # TensorRT
+                                         yolov5s.mlmodel            # CoreML (macOS-only)
+                                         yolov5s_saved_model        # TensorFlow SavedModel
+                                         yolov5s.pb                 # TensorFlow GraphDef
+                                         yolov5s.tflite             # TensorFlow Lite
+                                         yolov5s_edgetpu.tflite     # TensorFlow Edge TPU
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+import shlex
+import subprocess
+import sys
+import pytz
+import math
+import numpy as np
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+import torch
+import torch.backends.cudnn as cudnn
+
+import winsound
+import time
+
+FILE = Path(__file__).resolve()
+ROOT = FILE.parents[0]  # YOLOv5 root directory
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))  # add ROOT to PATH
+ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
+
+from models.common import DetectMultiBackend
+from utils.dataloaders import IMG_FORMATS, VID_FORMATS, LoadImages, LoadStreams
+from utils.general import (LOGGER, check_file, check_img_size, check_imshow, check_requirements, colorstr, cv2,
+                           increment_path, non_max_suppression, print_args, scale_coords, strip_optimizer, xyxy2xywh)
+from utils.plots import Annotator, colors, save_one_box
+from utils.torch_utils import select_device, time_sync
+
+from shapely.geometry import Polygon, LineString, Point
+from csv import writer
+from datetime import datetime, timedelta
+from analysis.height_estimation import EstimateCraneHookHeight
+
+# set timezone
+as_TKY = pytz.timezone('Asia/Tokyo') 
+os.environ['NUMEXPR_MAX_THREADS'] = '16'
+os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
+os.environ['FOR_DISABLE_CONSOLE_CTRL_HANDLER'] = '1'
+
+
+class OCRSubprocessBridge:
+    """Call an external OCR script in another virtual environment.
+
+    The bridge launches ``read_magnification_video_complete_fixed.py`` via
+    ``subprocess.run`` and parses its standard output (or an optional JSON
+    file) looking for an ``ocr_value`` entry.  Results are cached for a
+    configurable number of seconds to avoid spawning the OCR process for every
+    frame.  Only integer magnifications in the range 1-30 are considered
+    valid.
+    """
+
+    _REGEX_CANDIDATES = (
+        re.compile(r"\"ocr_value\"\s*[:=]\s*(?P<value>\d+)", re.IGNORECASE),
+        re.compile(r"ocr_value\s*[:=]\s*(?P<value>\d+)", re.IGNORECASE),
+    )
+
+    def __init__(
+        self,
+        python_executable: str,
+        script_path: str,
+        source: str,
+        *,
+        extra_args: Optional[Sequence[str]] = None,
+        timeout: float = 120.0,
+        cache_ttl: float = 10.0,
+        json_output: Optional[str] = None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self.python_executable = python_executable
+        self.script_path = script_path
+        self.source = source
+        self.extra_args: List[str] = list(extra_args or [])
+        self.timeout = timeout
+        self.cache_ttl = cache_ttl
+        self.json_output = json_output
+        self.logger = logger or logging.getLogger(__name__)
+
+        self._cached_value: Optional[int] = None
+        self._cached_ts: float = 0.0
+
+    @staticmethod
+    def _clamp_value(value: int) -> int:
+        return max(1, min(30, value))
+
+    def _parse_from_text(self, text: str) -> Optional[int]:
+        for pattern in self._REGEX_CANDIDATES:
+            match = pattern.search(text)
+            if match:
+                try:
+                    raw = int(match.group("value"))
+                except ValueError:
+                    continue
+                return self._clamp_value(raw)
+        return None
+
+    def _parse_from_json(self) -> Optional[int]:
+        if not self.json_output:
+            return None
+        json_path = Path(self.json_output)
+        if not json_path.exists():
+            return None
+        try:
+            payload = json.loads(json_path.read_text(encoding="utf-8"))
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logger.warning("Failed to read OCR JSON '%s': %s", json_path, exc)
+            return None
+        if isinstance(payload, dict):
+            candidate = payload.get("ocr_value")
+        else:
+            candidate = None
+        if candidate is None and isinstance(payload, dict):
+            # Allow nested outputs like {"results": {"ocr_value": 12}}
+            results = payload.get("results")
+            if isinstance(results, dict):
+                candidate = results.get("ocr_value")
+        if candidate is None:
+            return None
+        try:
+            return self._clamp_value(int(candidate))
+        except (TypeError, ValueError):
+            self.logger.warning("Invalid ocr_value '%s' in %s", candidate, json_path)
+            return None
+
+    def _run_process(self) -> str:
+        cmd = [self.python_executable, self.script_path]
+        if self.source:
+            cmd.extend(["--video", self.source])
+        cmd.extend(self.extra_args)
+        if self.json_output:
+            cmd.extend(["--output-json", self.json_output])
+        self.logger.info("Launching OCR subprocess: %s", " ".join(map(str, cmd)))
+        completed = subprocess.run(
+            cmd,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=self.timeout,
+        )
+        if completed.returncode != 0:
+            self.logger.warning(
+                "OCR subprocess exited with code %s", completed.returncode
+            )
+        return (completed.stdout or "") + "\n" + (completed.stderr or "")
+
+    def get_value(self, force: bool = False) -> Optional[int]:
+        now = time.time()
+        if (
+            not force
+            and self._cached_value is not None
+            and now - self._cached_ts < self.cache_ttl
+        ):
+            return self._cached_value
+
+        stdout_text = self._run_process()
+        value = self._parse_from_text(stdout_text)
+        if value is None:
+            value = self._parse_from_json()
+        if value is None:
+            self.logger.warning(
+                "Could not determine ocr_value from subprocess output"
+            )
+            return self._cached_value
+
+        self._cached_value = value
+        self._cached_ts = now
+        return value
+
+
+def compute_focal_length_from_ocr(ocr_value: Optional[float]) -> float:
+    """Interpolate the focal length in millimetres based on OCR zoom."""
+
+    if ocr_value is None:
+        return 6.0
+    try:
+        zoom = float(ocr_value)
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return 6.0
+    zoom = max(1.0, min(30.0, zoom))
+    return 6.0 + (180.0 - 6.0) * (zoom - 1.0) / 29.0
+
+class Queue:
+    def __init__(self):
+        self.items = []
+
+    def isEmpty(self):
+        return self.items == []
+
+    def enqueue(self, item):
+        self.items.insert(0,item)
+
+    def dequeue(self):
+        return self.items.pop()
+
+    def size(self):
+        return len(self.items)
+
+# set warining sound params (in msec)
+stime1 = 0
+stime2 = 0
+warn1_len = 3437
+warn2_len = 3135
+
+def display_warning(frame, warning_type, mute):
+    global stime1, stime2
+    global warn1_len, warn2_len
+    if warning_type == 1:
+        s_img = cv2.imread("warnings/warning1.png", cv2.IMREAD_UNCHANGED)
+        x_offset=75
+        y_offset=75
+        frame[y_offset:y_offset+s_img.shape[0], x_offset:x_offset+s_img.shape[1]] = s_img
+        ctime1 = int(time.time() * 1000)
+        if ctime1 - stime1 > warn1_len:
+            if not mute:
+                winsound.PlaySound("warnings/warning1a.wav", winsound.SND_FILENAME | winsound.SND_ASYNC )
+            stime1 = ctime1
+    elif warning_type == 2:
+        s_img = cv2.imread("warnings/warning2.png", cv2.IMREAD_UNCHANGED)
+        x_offset=75
+        y_offset=275
+        frame[y_offset:y_offset+s_img.shape[0], x_offset:x_offset+s_img.shape[1]] = s_img
+        ctime2 = int(time.time() * 1000)
+        if ctime2 - stime2 > warn2_len:
+            if not mute:
+                winsound.PlaySound("warnings/warning2a.wav", winsound.SND_FILENAME | winsound.SND_ASYNC )
+            stime2 = ctime2
+    else:
+        frame = frame
+    return frame
+
+
+def display_zoom_warning(frame, warning_type):
+    if warning_type == 1:
+        s_img = cv2.imread("warnings/zoom_up.png", cv2.IMREAD_UNCHANGED)
+        x_offset=25
+        y_offset=600
+        frame[y_offset:y_offset+s_img.shape[0], x_offset:x_offset+s_img.shape[1]] = s_img
+    elif warning_type == 2:
+        s_img = cv2.imread("warnings/zoom_down.png", cv2.IMREAD_UNCHANGED)
+        x_offset=25
+        y_offset=650
+        frame[y_offset:y_offset+s_img.shape[0], x_offset:x_offset+s_img.shape[1]] = s_img
+    else:
+        frame = frame
+    return frame
+
+def calc_queue_avg(queue, m):
+    queue_non_zero = list(filter(None,queue))
+    if len(queue_non_zero) >= m and queue:
+        return round(sum(queue_non_zero) / len(queue_non_zero))
+    else:
+        return 0
+
+def bbox_rel(*xyxy):
+    """" Calculates the relative bounding box from absolute pixel values. """
+    bbox_left = min([xyxy[0].item(), xyxy[2].item()])
+    bbox_top = min([xyxy[1].item(), xyxy[3].item()])
+    bbox_w = abs(xyxy[0].item() - xyxy[2].item())
+    bbox_h = abs(xyxy[1].item() - xyxy[3].item())
+    x_c = (bbox_left + bbox_w / 2)
+    y_c = (bbox_top + bbox_h / 2)
+    w = bbox_w
+    h = bbox_h
+    return x_c, y_c, w, h
+
+@torch.no_grad()
+def run(
+        weights=ROOT / 'yolov5s.pt',  # model.pt path(s)
+        source=ROOT / 'data/images',  # file/dir/URL/glob, 0 for webcam
+        data=ROOT / 'data/coco128.yaml',  # dataset.yaml path
+        imgsz=(640, 640),  # inference size (height, width)
+        skip_step=1, # inference every nth frame
+        conf_thres=0.25,  # confidence threshold
+        iou_thres=0.45,  # NMS IOU threshold
+        max_det=1000,  # maximum detections per image
+        crane_ratio_thres=4.2, # crane ratio threshold
+        crane_width_queue_args = [10,2],
+        helmet_width_queue_args = [10,2],
+        helmet_detect_queue_args = [10,1],
+        min_zoom_level = 10, # minimum camera zoom level
+        max_zoom_level = 25, # maximum camera zoom level
+        device='',  # cuda device, i.e. 0 or 0,1,2,3 or cpu
+        view_img=False,  # show results
+        save_txt=False,  # save results to *.txt
+        save_conf=False,  # save confidences in --save-txt labels
+        save_crop=False,  # save cropped prediction boxes
+        save_csv=False, # save results to *.csv
+        mute_warnings=False, # mute warning sounds
+        nosave=False,  # do not save images/videos
+        classes=None,  # filter by class: --class 0, or --class 0 2 3
+        agnostic_nms=False,  # class-agnostic NMS
+        augment=False,  # augmented inference
+        visualize=False,  # visualize features
+        update=False,  # update all models
+        project=ROOT / 'runs/detect',  # save results to project/name
+        name='exp',  # save results to project/name
+        exist_ok=False,  # existing project/name ok, do not increment
+        line_thickness=3,  # bounding box thickness (pixels)
+        hide_labels=False,  # hide labels
+        hide_conf=False,  # hide confidences
+        half=False,  # use FP16 half-precision inference
+        dnn=False,  # use OpenCV DNN for ONNX inference
+        ocr_python=None,
+        ocr_script=None,
+        ocr_source=None,
+        ocr_extra_args=None,
+        ocr_timeout=120.0,
+        ocr_cache_ttl=10.0,
+        ocr_output_json=None,
+        ocr_default=1.0,
+):
+
+    stime1 = 0
+    stime2 = 0
+    warn1_len = 7784
+    warn2_len = 9195
+    
+    source = str(source)
+    save_img = not nosave and not source.endswith('.txt')  # save inference images
+    ocr_value: Optional[int] = None
+    current_focal_length = compute_focal_length_from_ocr(ocr_default)
+    ocr_bridge: Optional[OCRSubprocessBridge] = None
+    height_estimator_error_reported = False
+
+    if ocr_python and ocr_script:
+        actual_source = str(ocr_source) if ocr_source is not None else source
+        try:
+            ocr_bridge = OCRSubprocessBridge(
+                python_executable=str(ocr_python),
+                script_path=str(ocr_script),
+                source=str(actual_source),
+                extra_args=list(ocr_extra_args or []),
+                timeout=float(ocr_timeout),
+                cache_ttl=float(ocr_cache_ttl),
+                json_output=str(ocr_output_json) if ocr_output_json else None,
+                logger=LOGGER,
+            )
+            ocr_value = ocr_bridge.get_value(force=True)
+            if ocr_value is None:
+                LOGGER.warning(
+                    "OCR bridge initial call failed; falling back to default magnification %.1f",
+                    ocr_default,
+                )
+        except Exception as exc:  # pragma: no cover - defensive
+            LOGGER.warning("Failed to initialise OCR subprocess bridge: %s", exc)
+            ocr_bridge = None
+    elif ocr_python or ocr_script:
+        LOGGER.warning("Both --ocr-python and --ocr-script must be provided to enable OCR integration.")
+
+    if ocr_value is None:
+        ocr_value = int(round(float(ocr_default))) if ocr_default is not None else None
+
+    current_focal_length = compute_focal_length_from_ocr(ocr_value)
+    LOGGER.info(
+        "Using initial magnification %s resulting in focal length %.2f mm",
+        ocr_value,
+        current_focal_length,
+    )
+    is_file = Path(source).suffix[1:] in (IMG_FORMATS + VID_FORMATS)
+    is_url = source.lower().startswith(('rtsp://', 'rtmp://', 'http://', 'https://'))
+    webcam = source.isnumeric() or source.endswith('.txt') or (is_url and not is_file)
+    if is_url and is_file:
+        source = check_file(source)  # download
+
+    # Directories
+    save_dir = increment_path(Path(project) / name, exist_ok=exist_ok)  # increment run
+    (save_dir / 'labels' if save_txt else save_dir).mkdir(parents=True, exist_ok=True)  # make dir
+
+    # Load model
+    device = select_device(device)
+    model = DetectMultiBackend(weights, device=device, dnn=dnn, data=data, fp16=half)
+    stride, names, pt = model.stride, model.names, model.pt
+    imgsz = check_img_size(imgsz, s=stride)  # check image size
+
+    # Dataloader
+    if webcam:
+        view_img = check_imshow()
+        cudnn.benchmark = True  # set True to speed up constant image size inference
+        dataset = LoadStreams(source, img_size=imgsz, stride=stride, auto=pt, skip_step=skip_step)
+        bs = len(dataset)  # batch_size
+    else:
+        dataset = LoadImages(source, img_size=imgsz, stride=stride, auto=pt)
+        bs = 1  # batch_size
+    vid_path, vid_writer = [None] * bs, [None] * bs
+
+    if webcam:
+        prev_im = [None] * bs
+
+    # initialize queues
+    helmet_width_queue = Queue()
+    crane_width_queue = Queue()
+    helmet_detect_queue = Queue()
+
+    # initialize queue parameters
+    h_k, h_m = helmet_width_queue_args
+    c_k, c_m = crane_width_queue_args
+
+    hd_k, hd_m = helmet_detect_queue_args
+
+    # Run inference
+    model.warmup(imgsz=(1 if pt else bs, 3, *imgsz))  # warmup
+    dt, seen = [0.0, 0.0, 0.0], 0
+    for path, im, im0s, vid_cap, s in dataset:
+        if webcam:
+            # Optimize repeated img
+            if (prev_im == im).all():
+                continue
+            prev_im = im
+
+        t1 = time_sync()
+        im = torch.from_numpy(im).to(device)
+        im = im.half() if model.fp16 else im.float()  # uint8 to fp16/32
+        im /= 255  # 0 - 255 to 0.0 - 1.0
+        if len(im.shape) == 3:
+            im = im[None]  # expand for batch dim
+        t2 = time_sync()
+        dt[0] += t2 - t1
+
+        # Inference
+        visualize = increment_path(save_dir / Path(path).stem, mkdir=True) if visualize else False
+        pred = model(im, augment=augment, visualize=visualize)
+        t3 = time_sync()
+        dt[1] += t3 - t2
+
+        # NMS
+        pred = non_max_suppression(pred, conf_thres, iou_thres, classes, agnostic_nms, max_det=max_det)
+        dt[2] += time_sync() - t3
+
+        # Second-stage classifier (optional)
+        # pred = utils.general.apply_classifier(pred, classifier_model, im, im0s)
+
+        # Process predictions
+        for i, det in enumerate(pred):  # per image
+            seen += 1
+            if webcam:  # batch_size >= 1
+                p, im0, frame = path[i], im0s[i].copy(), dataset.count
+                s += f'{i}: '
+            else:
+                p, im0, frame = path, im0s.copy(), getattr(dataset, 'frame', 0)
+
+            p = Path(p)  # to Path
+            save_path = str(save_dir / p.name)  # im.jpg
+            csv_path =  str(save_dir / p.stem)  # im.csv
+            txt_path = str(save_dir / 'labels' / p.stem) + ('' if dataset.mode == 'image' else f'_{frame}')  # im.txt
+            s += '%gx%g ' % im.shape[2:]  # print string
+            gn = torch.tensor(im0.shape)[[1, 0, 1, 0]]  # normalization gain whwh
+            imc = im0.copy() if save_crop else im0  # for save_crop
+            annotator = Annotator(im0, line_width=line_thickness, example=str(names))
+
+            if not webcam:
+                curr_time = datetime.fromtimestamp(frame/30).strftime('%H:%M:%S.%f')
+                cv2.putText(im0, 'Frame: {0}'.format(frame), ((im0.shape[1]-300), 50), cv2.FONT_HERSHEY_SIMPLEX,
+                        1, (255, 255, 255), 2, cv2.LINE_AA)
+            else:
+                curr_time = datetime.now(as_TKY).strftime("%Y-%m-%d %H:%M:%S.%f")
+                curr_time_vis = datetime.now(as_TKY).strftime("%Y-%m-%d %H:%M:%S")
+                cv2.putText(im0, 'Time: {0}'.format(curr_time_vis), ((im0.shape[1]-500), 50), cv2.FONT_HERSHEY_SIMPLEX,
+                        1, (255, 255, 255), 2, cv2.LINE_AA)
+
+            if ocr_value is not None:
+                zoom_text = f'Zoom: {ocr_value}x  f={current_focal_length:.1f}mm'
+                y_offset = 90 if webcam else 50
+                cv2.putText(
+                    im0,
+                    zoom_text,
+                    (30, y_offset),
+                    cv2.FONT_HERSHEY_SIMPLEX,
+                    0.9,
+                    (0, 255, 255),
+                    2,
+                    cv2.LINE_AA,
+                )
+                
+            # Dequeue queues if k limit is reached
+            if crane_width_queue.size() == c_k and crane_width_queue.size() != 0:
+                crane_width_queue.dequeue()
+            
+            if helmet_width_queue.size() == h_k and helmet_width_queue.size() != 0:
+                helmet_width_queue.dequeue()
+            
+            if helmet_detect_queue.size() == hd_k and helmet_detect_queue.size() != 0:
+                helmet_detect_queue.dequeue()
+
+            if len(det):
+                # Rescale boxes from img_size to im0 size
+                det[:, :4] = scale_coords(im.shape[2:], det[:, :4], im0.shape).round()
+
+                # Print results
+                for c in det[:, -1].unique():
+                    n = (det[:, -1] == c).sum()  # detections per class
+                    s += f"{n} {names[int(c)]}{'s' * (n > 1)}, "  # add to string
+
+                # Write results
+                det_dict = {0:[],1:[],2:[],3:[],4:[]}
+
+                warning = 0
+                zoom_warning = 0
+                crane_ratio = 0
+                
+                # Write results
+                for *xyxy, conf, cls in reversed(det):
+
+                    x_c, y_c, bbox_w, bbox_h = bbox_rel(*xyxy)
+                    c = int(cls)
+                    obj = names[c]
+                    data = [frame,curr_time,obj,float(conf),x_c,y_c,bbox_w,bbox_h,crane_ratio,warning,'','','','','','']
+
+                    # append data to detection dictionary
+                    if c not in det_dict:
+                        det_dict[c] = []
+                    det_dict[c].append(data)
+
+                    if save_txt:  # Write to file
+                        xywh = (xyxy2xywh(torch.tensor(xyxy).view(1, 4)) / gn).view(-1).tolist()  # normalized xywh
+                        line = (cls, *xywh, conf) if save_conf else (cls, *xywh)  # label format
+                        with open(f'{txt_path}.txt', 'a') as f:
+                            f.write(('%g ' * len(line)).rstrip() % line + '\n')
+
+                    if save_img or save_crop or view_img:  # Add bbox to image
+                        c = int(cls)  # integer class
+                        label = None if hide_labels else (names[c] if hide_conf else f'{names[c]} {conf:.2f}')
+                        annotator.box_label(xyxy, label, color=colors(c, True))
+                    if save_crop:
+                        save_one_box(xyxy, imc, file=save_dir / 'crops' / names[c] / f'{p.stem}.jpg', BGR=True)
+                
+                # Add helmet and crane sizes to queues if exists
+                if det_dict[3]: # crane entry
+                    det_dict[3] = sorted(det_dict[3], key=lambda x: x[3])[::-1] # sort crane hooks by highest conf level
+                    crane = det_dict[3][0]
+                    crane_width_queue.enqueue(crane[6])
+                else:
+                    crane_width_queue.enqueue(0)
+
+                helmets = det_dict[1] + det_dict[4] # combine helmets detections
+                
+
+                if helmets: # check for helmet detections
+                    helmets = sorted(helmets, key=lambda x: max(x[6],x[7]))[::-1] # sort helmets by max(helmet_width, helmet_height)
+                    helmet_width_queue.enqueue(max(helmets[0][6],helmets[0][7]))
+                    helmet_detect_queue.enqueue({'helmet': det_dict[1], 'cross': det_dict[4]}) # add detections to queue
+                else:
+                    helmet_width_queue.enqueue(0)
+                    helmet_detect_queue.enqueue({}) # add detections to queue
+                
+                # Calculated averages sizes
+                avg_crane = calc_queue_avg(crane_width_queue.items, c_m)
+                avg_helmet = calc_queue_avg(helmet_width_queue.items, h_m)
+
+                # Determine zoom warning
+                if avg_helmet > 0 and avg_helmet <= min_zoom_level:
+                    zoom_warning = 1
+                elif avg_helmet >= max_zoom_level:
+                    zoom_warning = 2
+                else:
+                    zoom_warning = 0
+
+                # Calculate HD
+                helmet_detect_binary = [1 if l else 0 for l in helmet_detect_queue.items]
+                helmet_det_cnt = helmet_detect_binary.count(1) # number of detections last 10 frames
+
+                if helmet_det_cnt >= hd_m:
+                    helmet_detect = 1
+                else:
+                    helmet_detect = 0
+                    
+                if avg_crane > 0 and avg_helmet > 0: # check both crane and helmet values exists
+
+                    if ocr_bridge:
+                        try:
+                            refreshed_value = ocr_bridge.get_value()
+                        except Exception as exc:  # pragma: no cover - defensive
+                            LOGGER.warning("Failed to refresh OCR magnification: %s", exc)
+                        else:
+                            if refreshed_value is not None and refreshed_value != ocr_value:
+                                ocr_value = refreshed_value
+                                current_focal_length = compute_focal_length_from_ocr(ocr_value)
+                                LOGGER.info(
+                                    "Updated magnification %sx -> focal length %.2f mm",
+                                    ocr_value,
+                                    current_focal_length,
+                                )
+
+                    try:
+                        crane_height, crane_ratio = EstimateCraneHookHeight(
+                            avg_helmet,
+                            avg_crane,
+                            focal_length=current_focal_length,
+                        )
+                    except TypeError:
+                        try:
+                            crane_height, crane_ratio = EstimateCraneHookHeight(
+                                avg_helmet,
+                                avg_crane,
+                                current_focal_length,
+                            )
+                        except TypeError:
+                            crane_height, crane_ratio = EstimateCraneHookHeight(avg_helmet, avg_crane)
+                            if not height_estimator_error_reported:
+                                LOGGER.warning(
+                                    "EstimateCraneHookHeight does not accept a focal length parameter; "
+                                    "falling back to legacy behaviour.")
+                                height_estimator_error_reported = True
+
+                    if bool(helmet_detect): # check helmet detection in last n detections
+
+                        helmet_index = np.min(np.nonzero(helmet_detect_binary)) # latest detection index
+                        latest_helmet = helmet_detect_queue.items[helmet_index]
+                    
+                    # Calculate warnings
+                    if 0 < crane_ratio and crane_ratio < crane_ratio_thres: # if low height
+
+                        list_cross_helmets = [a_dict['cross'] for a_dict in helmet_detect_queue.items if a_dict]
+                        cross_helmet_bool = any(list_cross_helmets) # check if any cross_helmets in queue
+
+                        if bool(helmet_detect) and not cross_helmet_bool and latest_helmet['helmet']: # if no cross helmet in image while normal helmet in image
+                            warning = 2
+                    
+                    elif crane_ratio > crane_ratio_thres:
+                        # make buffer
+                        crane_buf = Point(int(crane[4]), int(crane[5])).buffer(10*avg_helmet)
+
+                        # draw buffer red
+                        cv2.circle(im0, (int(crane[4]), int(crane[5])), (10*avg_helmet), (0, 0, 255), 2)
+
+                        for helmet in latest_helmet['helmet'] + latest_helmet['cross']: # helmet detections
+                            if bool(helmet_detect) and crane_buf.contains(Point(helmet[4], helmet[5])): # if any helmet in buffer
+                                warning = 1
+                    else:
+                        warning = 0
+                else:
+                    crane_ratio = 0
+
+                # Write vars to crane entry
+                if det_dict[3]: # only write analysis vars if crane exists
+
+                    # Helmet/Crane ratio
+                    det_dict[3][0][8] = crane_ratio
+
+                    # Warnings
+                    det_dict[3][0][9] = warning
+
+                    # Object size lists
+                    det_dict[3][0][10] = crane_width_queue.items
+                    det_dict[3][0][11] = helmet_width_queue.items
+
+                    # Object detection lists
+                    det_dict[3][0][12] = helmet_detect_binary
+
+                    # Avg values
+                    det_dict[3][0][13] = avg_crane
+                    det_dict[3][0][14] = avg_helmet
+                    det_dict[3][0][15] = helmet_detect
+
+                if save_csv: # Write to CSV
+                    # write the header if not exists
+                    if not (os.path.exists(csv_path + '.csv')):
+                        header = ['frame','time','class','confidence','x_local','y_local','box_width','box_height',
+                                  'crane_helmet_ratio','crane_warning','crane_size_list','helmet_size_list',
+                                  'helmet_detect_list','avg_crane_width','avg_helmet_width','helmet_detect']
+                        
+                        with open(csv_path + '.csv', 'w+', encoding='UTF8', newline='') as csvf:
+                            csv_writer = writer(csvf)
+                            csv_writer.writerow(header)
+
+                    for key in det_dict:
+                        for det in det_dict[key]:
+                            # write detection entries
+                            with open(csv_path + '.csv', 'a', encoding='UTF8', newline='') as csvf:
+                                csv_writer = writer(csvf)
+                                csv_writer.writerow(det)
+
+                # Evaluate warning signs for this frame
+                im0 = display_warning(im0,warning, mute_warnings)
+                im0 = display_zoom_warning(im0, zoom_warning)
+
+            else: # if no detections add 0 to all lists
+                crane_width_queue.enqueue(0)
+                helmet_width_queue.enqueue(0)
+                helmet_detect_queue.enqueue({})
+
+            # Stream results
+            im0 = annotator.result()
+            if view_img:
+                cv2.imshow(str(p), im0)
+                cv2.waitKey(1)  # 1 millisecond
+
+            # Save results (image with detections)
+            if save_img:
+                if dataset.mode == 'image':
+                    cv2.imwrite(save_path, im0)
+                else:  # 'video' or 'stream'
+                    if vid_path[i] != save_path:  # new video
+                        vid_path[i] = save_path
+                        if isinstance(vid_writer[i], cv2.VideoWriter):
+                            vid_writer[i].release()  # release previous video writer
+                        if vid_cap:  # video
+                            fps = vid_cap.get(cv2.CAP_PROP_FPS)
+                            w = int(vid_cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+                            h = int(vid_cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+                        else:  # stream
+                            fps, w, h = 30, im0.shape[1], im0.shape[0]
+                        save_path = str(Path(save_path).with_suffix('.mp4'))  # force *.mp4 suffix on results videos
+                        vid_writer[i] = cv2.VideoWriter(save_path, cv2.VideoWriter_fourcc(*'mp4v'), fps, (w, h))
+                    vid_writer[i].write(im0)
+
+        # Print time (inference-only)
+        LOGGER.info(f'{s}Done. ({t3 - t2:.3f}s)')
+
+    # Print results
+    t = tuple(x / seen * 1E3 for x in dt)  # speeds per image
+    LOGGER.info(f'Speed: %.1fms pre-process, %.1fms inference, %.1fms NMS per image at shape {(1, 3, *imgsz)}' % t)
+    if save_txt or save_img:
+        s = f"\n{len(list(save_dir.glob('labels/*.txt')))} labels saved to {save_dir / 'labels'}" if save_txt else ''
+        LOGGER.info(f"Results saved to {colorstr('bold', save_dir)}{s}")
+    if update:
+        strip_optimizer(weights)  # update model (to fix SourceChangeWarning)
+
+
+def parse_opt():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--weights', nargs='+', type=str, default=ROOT / 'yolov5s.pt', help='model path(s)')
+    parser.add_argument('--source', type=str, default=ROOT / 'data/images', help='file/dir/URL/glob, 0 for webcam')
+    parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='(optional) dataset.yaml path')
+    parser.add_argument('--imgsz', '--img', '--img-size', nargs='+', type=int, default=[640], help='inference size h,w')
+    parser.add_argument('--skip-step', type=int, default=1, help='default read every frame for streams')
+    parser.add_argument('--conf-thres', type=float, default=0.25, help='confidence threshold')
+    parser.add_argument('--iou-thres', type=float, default=0.45, help='NMS IoU threshold')
+    parser.add_argument('--max-det', type=int, default=1000, help='maximum detections per image')
+    parser.add_argument('--crane-ratio-thres', type=float, default=4.2, help='crane ratio threshold')
+    parser.add_argument('--crane-width-queue-args', nargs='+', type=int, default=[10,2], help='crane queue arguments')
+    parser.add_argument('--helmet-width-queue-args', nargs='+', type=int, default=[10,2], help='helmet queue arguments')
+    parser.add_argument('--helmet-detect-queue-args', nargs='+', type=int, default=[10,1], help='helmet detect queue arguments')
+    parser.add_argument('--min-zoom-level', type=int, default=10, help='minimum camera zoom level')
+    parser.add_argument('--max-zoom-level', type=int, default=25, help='maximum camera zoom level')
+    parser.add_argument('--ocr-python', help='Python interpreter inside the OCR virtual environment')
+    parser.add_argument('--ocr-script', help='Path to read_magnification_video_complete_fixed.py')
+    parser.add_argument('--ocr-source', help='Optional video path passed to the OCR script (defaults to --source)')
+    parser.add_argument('--ocr-extra-args', default='', help='Additional command line arguments for the OCR script')
+    parser.add_argument('--ocr-timeout', type=float, default=120.0, help='Timeout (seconds) for the OCR subprocess')
+    parser.add_argument('--ocr-cache-ttl', type=float, default=10.0, help='Minimum seconds between OCR subprocess executions')
+    parser.add_argument('--ocr-output-json', help='JSON file written by the OCR script containing ocr_value')
+    parser.add_argument('--ocr-default', type=float, default=1.0, help='Fallback magnification if OCR fails')
+    parser.add_argument('--device', default='', help='cuda device, i.e. 0 or 0,1,2,3 or cpu')
+    parser.add_argument('--view-img', action='store_true', help='show results')
+    parser.add_argument('--save-txt', action='store_true', help='save results to *.txt')
+    parser.add_argument('--save-conf', action='store_true', help='save confidences in --save-txt labels')
+    parser.add_argument('--save-crop', action='store_true', help='save cropped prediction boxes')
+    parser.add_argument('--save-csv', action='store_true', help='save results to *.csv')
+    parser.add_argument('--mute-warnings', action='store_true', help='mute warning sound')
+    parser.add_argument('--nosave', action='store_true', help='do not save images/videos')
+    parser.add_argument('--classes', nargs='+', type=int, help='filter by class: --classes 0, or --classes 0 2 3')
+    parser.add_argument('--agnostic-nms', action='store_true', help='class-agnostic NMS')
+    parser.add_argument('--augment', action='store_true', help='augmented inference')
+    parser.add_argument('--visualize', action='store_true', help='visualize features')
+    parser.add_argument('--update', action='store_true', help='update all models')
+    parser.add_argument('--project', default=ROOT / 'runs/detect', help='save results to project/name')
+    parser.add_argument('--name', default='exp', help='save results to project/name')
+    parser.add_argument('--exist-ok', action='store_true', help='existing project/name ok, do not increment')
+    parser.add_argument('--line-thickness', default=3, type=int, help='bounding box thickness (pixels)')
+    parser.add_argument('--hide-labels', default=False, action='store_true', help='hide labels')
+    parser.add_argument('--hide-conf', default=False, action='store_true', help='hide confidences')
+    parser.add_argument('--half', action='store_true', help='use FP16 half-precision inference')
+    parser.add_argument('--dnn', action='store_true', help='use OpenCV DNN for ONNX inference')
+    opt = parser.parse_args()
+    opt.imgsz *= 2 if len(opt.imgsz) == 1 else 1      # expand
+    print_args(vars(opt))
+    return opt
+
+
+def main(opt):
+    check_requirements(exclude=('tensorboard', 'thop'))
+    if hasattr(opt, 'ocr_extra_args') and isinstance(opt.ocr_extra_args, str):
+        opt.ocr_extra_args = shlex.split(opt.ocr_extra_args)
+    run(**vars(opt))
+
+
+if __name__ == "__main__":
+    opt = parse_opt()
+    main(opt)

--- a/read_multiplier.py
+++ b/read_multiplier.py
@@ -1,0 +1,1097 @@
+#!/usr/bin/env python3
+"""
+read_multiplier.py
+
+固定位置に表示される「×n」表記から右側の整数を読み取るスクリプト。
+
+実行例:
+    python read_multiplier.py --video "/mnt/data/ズーム動画.mp4" --fps 5 --roi 1200 70 80 50 --save-annotated
+    python read_multiplier.py --video "/mnt/data/ズーム動画.mp4" --fps 5 --auto-roi --track --save-annotated
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+from collections import Counter, deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Deque, Dict, List, Optional, Sequence, Tuple
+
+import cv2
+import numpy as np
+
+
+# ----------------------------- OCR Engine Wrapper -----------------------------
+
+
+class BaseOCREngine:
+    """Common interface for OCR engines."""
+
+    name: str = "base"
+
+    def recognize(self, image: np.ndarray) -> List[Tuple[str, float]]:
+        raise NotImplementedError
+
+
+class PaddleEngine(BaseOCREngine):
+    name = "paddle"
+
+    def __init__(self, use_gpu: bool = False) -> None:
+        from paddleocr import PaddleOCR  # type: ignore
+
+        self.ocr = PaddleOCR(lang="en", use_angle_cls=False, show_log=False, use_gpu=use_gpu)
+
+    def recognize(self, image: np.ndarray) -> List[Tuple[str, float]]:
+        # PaddleOCR expects RGB images.
+        if image.ndim == 2:
+            rgb = cv2.cvtColor(image, cv2.COLOR_GRAY2RGB)
+        else:
+            rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+        result = self.ocr.ocr(rgb, cls=False)
+        outputs: List[Tuple[str, float]] = []
+        for line in result:
+            if not line:
+                continue
+            text, confidence = line[1]
+            outputs.append((str(text), float(confidence)))
+        return outputs
+
+
+class EasyOCREngine(BaseOCREngine):
+    name = "easyocr"
+
+    def __init__(self) -> None:
+        import easyocr  # type: ignore
+
+        self.reader = easyocr.Reader(["en"], gpu=False, verbose=False)
+
+    def recognize(self, image: np.ndarray) -> List[Tuple[str, float]]:
+        if image.ndim == 2:
+            to_ocr = image
+        else:
+            to_ocr = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        results = self.reader.readtext(to_ocr)
+        outputs: List[Tuple[str, float]] = []
+        for _, text, confidence in results:
+            outputs.append((str(text), float(confidence)))
+        return outputs
+
+
+class TesseractEngine(BaseOCREngine):
+    name = "tesseract"
+
+    def __init__(self) -> None:
+        import pytesseract  # type: ignore
+
+        from pytesseract import Output  # type: ignore
+
+        self.pytesseract = pytesseract
+        self.output = Output
+        self.config = "--psm 7 --oem 3 -c tessedit_char_whitelist=0123456789"
+
+    def recognize(self, image: np.ndarray) -> List[Tuple[str, float]]:
+        if image.ndim == 3:
+            gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        else:
+            gray = image
+        data = self.pytesseract.image_to_data(gray, output_type=self.output.DICT, config=self.config)
+        outputs: List[Tuple[str, float]] = []
+        for text, conf in zip(data.get("text", []), data.get("conf", [])):
+            if text is None:
+                continue
+            cleaned = text.strip()
+            if not cleaned:
+                continue
+            try:
+                conf_float = float(conf)
+            except (TypeError, ValueError):
+                conf_float = 0.0
+            if conf_float < 0:
+                conf_float = 0.0
+            outputs.append((cleaned, conf_float / 100.0))
+        return outputs
+
+
+def initialize_ocr_engine(preferred: str = "auto", allow_gpu: bool = False) -> BaseOCREngine:
+    """Instantiate available OCR engine following preference order."""
+
+    errors: Dict[str, str] = {}
+    order = ["paddle", "easyocr", "tesseract"] if preferred == "auto" else [preferred]
+    # Append fallbacks if not already included
+    if preferred != "auto":
+        for name in ["paddle", "easyocr", "tesseract"]:
+            if name not in order:
+                order.append(name)
+
+    for name in order:
+        try:
+            if name == "paddle":
+                return PaddleEngine(use_gpu=allow_gpu)
+            if name == "easyocr":
+                return EasyOCREngine()
+            if name == "tesseract":
+                return TesseractEngine()
+        except Exception as exc:  # pragma: no cover - informative logging
+            errors[name] = str(exc)
+            continue
+    raise RuntimeError(f"No OCR engine could be initialized. Errors: {errors}")
+
+
+# ------------------------------ Helper Classes -------------------------------
+
+
+@dataclass
+class ROI:
+    x: int
+    y: int
+    w: int
+    h: int
+
+    def clamp(self, width: int, height: int) -> "ROI":
+        x = max(0, min(self.x, width - 1))
+        y = max(0, min(self.y, height - 1))
+        w = max(1, min(self.w, width - x))
+        h = max(1, min(self.h, height - y))
+        return ROI(x, y, w, h)
+
+    def to_tuple(self) -> Tuple[int, int, int, int]:
+        return self.x, self.y, self.w, self.h
+
+
+class ValueSmoother:
+    """Mode voting smoother for temporal stabilization."""
+
+    def __init__(self, window_size: int = 5) -> None:
+        self.window_size = max(1, window_size)
+        self.buffer: Deque[str] = deque(maxlen=self.window_size)
+
+    def update(self, value: str) -> str:
+        if value:
+            self.buffer.append(value)
+        if not self.buffer:
+            return value
+        counts = Counter(self.buffer)
+        max_count = max(counts.values())
+        candidates = [val for val, cnt in counts.items() if cnt == max_count]
+        if value and value in candidates:
+            return value
+        # choose the most recent candidate
+        for stored in reversed(self.buffer):
+            if stored in candidates:
+                return stored
+        return value
+
+
+# ------------------------------ Utility Methods ------------------------------
+
+
+def build_cross_template(size: int = 45, thickness: int = 6) -> np.ndarray:
+    """Generate a synthetic '×' template for template matching."""
+
+    size = max(15, size)
+    thickness = max(1, thickness)
+    template = np.zeros((size, size), dtype=np.uint8)
+    cv2.line(template, (0, 0), (size - 1, size - 1), 255, thickness)
+    cv2.line(template, (size - 1, 0), (0, size - 1), 255, thickness)
+    template = cv2.GaussianBlur(template, (3, 3), 0)
+    return template
+
+
+def preprocess_for_ocr(
+    roi_img: np.ndarray,
+    scale_factor: float = 2.5,
+    clahe_clip: float = 2.0,
+    clahe_grid: Tuple[int, int] = (8, 8),
+    adaptive: bool = False,
+) -> np.ndarray:
+    """Apply contrast enhancement and binarization before OCR."""
+
+    if roi_img.ndim == 3:
+        gray = cv2.cvtColor(roi_img, cv2.COLOR_BGR2GRAY)
+    else:
+        gray = roi_img
+
+    clahe = cv2.createCLAHE(clipLimit=clahe_clip, tileGridSize=clahe_grid)
+    enhanced = clahe.apply(gray)
+
+    blurred = cv2.GaussianBlur(enhanced, (0, 0), sigmaX=1.0)
+    unsharp = cv2.addWeighted(enhanced, 1.5, blurred, -0.5, 0)
+
+    if adaptive:
+        processed = cv2.adaptiveThreshold(
+            unsharp,
+            255,
+            cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
+            cv2.THRESH_BINARY,
+            31,
+            3,
+        )
+    else:
+        _, processed = cv2.threshold(unsharp, 0, 255, cv2.THRESH_BINARY | cv2.THRESH_OTSU)
+
+    if scale_factor != 1.0:
+        processed = cv2.resize(
+            processed,
+            None,
+            fx=scale_factor,
+            fy=scale_factor,
+            interpolation=cv2.INTER_CUBIC,
+        )
+
+    kernel = np.ones((3, 3), dtype=np.uint8)
+    processed = cv2.dilate(processed, kernel, iterations=1)
+    return processed
+
+
+def build_digit_mask(
+    image: np.ndarray,
+    clahe_clip: float = 2.0,
+    clahe_grid: Tuple[int, int] = (8, 8),
+    adaptive: bool = False,
+    color_hint: Optional[Tuple[int, int, int]] = None,
+    color_tolerance: int = 30,
+) -> np.ndarray:
+    """Create a binary mask emphasizing the digit strokes."""
+
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY) if image.ndim == 3 else image
+    clahe = cv2.createCLAHE(clipLimit=max(1.0, clahe_clip), tileGridSize=clahe_grid)
+    enhanced = clahe.apply(gray)
+    blurred = cv2.GaussianBlur(enhanced, (3, 3), 0)
+
+    if adaptive:
+        binary = cv2.adaptiveThreshold(
+            blurred,
+            255,
+            cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
+            cv2.THRESH_BINARY,
+            15,
+            2,
+        )
+    else:
+        _, binary = cv2.threshold(blurred, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+
+    if color_hint is not None:
+        target = np.array(color_hint, dtype=np.int16)
+        diff = np.abs(image.astype(np.int16) - target)
+        channel_diff = diff.max(axis=2)
+        mask = (channel_diff <= max(1, color_tolerance)).astype(np.uint8) * 255
+        binary = cv2.bitwise_and(binary, mask)
+
+    white_ratio = float(cv2.countNonZero(binary)) / float(binary.size or 1)
+    if white_ratio < 0.1:
+        binary = cv2.bitwise_not(binary)
+
+    kernel = np.ones((3, 3), dtype=np.uint8)
+    binary = cv2.morphologyEx(binary, cv2.MORPH_CLOSE, kernel, iterations=1)
+    return binary
+
+
+def _active_span(values: np.ndarray, min_len: int, threshold: float) -> Optional[Tuple[int, int]]:
+    active_idx = np.where(values >= threshold)[0]
+    if active_idx.size == 0:
+        return None
+    start = int(active_idx[0])
+    end = int(active_idx[-1])
+    if end - start + 1 < min_len:
+        return None
+    return start, end
+
+
+def refine_digit_roi(
+    frame: np.ndarray,
+    digit_roi: ROI,
+    clahe_clip: float,
+    clahe_grid: Tuple[int, int],
+    adaptive: bool,
+    color_hint: Optional[Tuple[int, int, int]],
+    color_tolerance: int,
+    min_band_px: int = 8,
+    min_x: Optional[int] = None,
+) -> Tuple[ROI, np.ndarray]:
+    """Tighten the digit ROI to active columns/rows and return its mask."""
+
+    h, w = frame.shape[:2]
+    digit_roi = digit_roi.clamp(w, h)
+    crop = frame[digit_roi.y : digit_roi.y + digit_roi.h, digit_roi.x : digit_roi.x + digit_roi.w]
+    if crop.size == 0:
+        return digit_roi, np.zeros((1, 1), dtype=np.uint8)
+
+    mask = build_digit_mask(
+        crop,
+        clahe_clip=clahe_clip,
+        clahe_grid=clahe_grid,
+        adaptive=adaptive,
+        color_hint=color_hint,
+        color_tolerance=color_tolerance,
+    )
+
+    if min_x is not None:
+        min_col_start = max(0, min_x - digit_roi.x)
+        if min_col_start > 0:
+            mask[:, :min_col_start] = 0
+
+    cols = mask.sum(axis=0) / 255.0
+    rows = mask.sum(axis=1) / 255.0
+    col_threshold = max(1.0, 0.12 * mask.shape[0])
+    row_threshold = max(1.0, 0.10 * mask.shape[1])
+
+    col_span = _active_span(cols, min_band_px, col_threshold)
+    row_span = _active_span(rows, max(3, int(0.5 * mask.shape[0])), row_threshold)
+
+    if col_span:
+        start_x, end_x = col_span
+        start_x = max(0, start_x - 1)
+        end_x = min(mask.shape[1] - 1, end_x + 1)
+        digit_roi = ROI(digit_roi.x + start_x, digit_roi.y, end_x - start_x + 1, digit_roi.h)
+        mask = mask[:, start_x : end_x + 1]
+    if row_span:
+        start_y, end_y = row_span
+        start_y = max(0, start_y - 1)
+        end_y = min(mask.shape[0] - 1, end_y + 1)
+        digit_roi = ROI(digit_roi.x, digit_roi.y + start_y, digit_roi.w, end_y - start_y + 1)
+        mask = mask[start_y : end_y + 1, :]
+
+    return digit_roi.clamp(w, h), mask
+
+
+def split_digit_segments(mask: np.ndarray, expected: int) -> List[np.ndarray]:
+    if mask.size == 0:
+        return []
+    cols = mask.sum(axis=0) / 255.0
+    gap_threshold = max(1.0, 0.05 * mask.shape[0])
+    segments: List[Tuple[int, int]] = []
+    start = 0
+    for idx in range(mask.shape[1]):
+        if cols[idx] <= gap_threshold:
+            if idx - start >= 3:
+                segments.append((start, idx - 1))
+            start = idx + 1
+    if mask.shape[1] - start >= 3:
+        segments.append((start, mask.shape[1] - 1))
+
+    if not segments and expected > 0:
+        width = mask.shape[1]
+        chunk = max(1, width // expected)
+        segments = [(i * chunk, min(width - 1, (i + 1) * chunk - 1)) for i in range(expected)]
+
+    if expected and len(segments) != expected:
+        if len(segments) > expected:
+            segments = segments[:expected]
+        else:
+            while len(segments) < expected:
+                last = segments[-1] if segments else (0, mask.shape[1] - 1)
+                segments.append(last)
+
+    extracted: List[np.ndarray] = []
+    for start_col, end_col in segments:
+        extracted.append(mask[:, start_col : end_col + 1])
+    return extracted
+
+
+def count_holes(mask: np.ndarray) -> int:
+    if mask.size == 0:
+        return 0
+    inverted = cv2.bitwise_not(mask)
+    num_labels, labels = cv2.connectedComponents(inverted)
+    hole_labels: List[int] = []
+    h, w = mask.shape
+    for label in range(1, num_labels):
+        component = labels == label
+        if not component.any():
+            continue
+        touches_border = (
+            component[0, :].any()
+            or component[-1, :].any()
+            or component[:, 0].any()
+            or component[:, -1].any()
+        )
+        if not touches_border:
+            hole_labels.append(label)
+    return len(hole_labels)
+
+
+def disambiguate_three_eight(value: str, mask: np.ndarray) -> str:
+    if not value or not value.isdigit():
+        return value
+    segments = split_digit_segments(mask, len(value)) if mask.size else []
+    if not segments:
+        return value
+    chars = list(value)
+    for idx, segment_mask in enumerate(segments):
+        if idx >= len(chars):
+            break
+        char = chars[idx]
+        if char not in {"3", "8"}:
+            continue
+        holes = count_holes(segment_mask)
+        if char == "3" and holes >= 2:
+            chars[idx] = "8"
+        elif char == "8" and holes == 0:
+            chars[idx] = "3"
+    return "".join(chars)
+
+
+def extract_numeric_candidate(recognitions: Sequence[Tuple[str, float]], whitelist_regex: str = r"^[0-9]{1,2}$") -> Tuple[str, float]:
+    """Pick the best numeric candidate from OCR outputs."""
+
+    best_value = ""
+    best_conf = 0.0
+    for text, conf in recognitions:
+        cleaned = text.strip().replace(" ", "")
+        cleaned = cleaned.replace("O", "0").replace("o", "0")
+        cleaned = cleaned.replace("l", "1").replace("I", "1")
+        cleaned = cleaned.replace("|", "1")
+        if cleaned.endswith("."):
+            cleaned = cleaned[:-1]
+        if not cleaned:
+            continue
+        if not re_match(whitelist_regex, cleaned):
+            continue
+        if conf >= best_conf:
+            best_value = cleaned
+            best_conf = conf
+    return best_value, best_conf
+
+
+def re_match(pattern: str, text: str) -> bool:
+    import re
+
+    return re.fullmatch(pattern, text) is not None
+
+
+def annotate_frame(
+    frame: np.ndarray,
+    roi: ROI,
+    digit_roi: ROI,
+    value: str,
+    confidence: float,
+    output_path: Path,
+) -> None:
+    """Save an annotated frame showing ROI, digit band, and OCR result."""
+
+    annotated = frame.copy()
+    cv2.rectangle(annotated, (roi.x, roi.y), (roi.x + roi.w, roi.y + roi.h), (0, 255, 255), 2)
+    cv2.rectangle(
+        annotated,
+        (digit_roi.x, digit_roi.y),
+        (digit_roi.x + digit_roi.w, digit_roi.y + digit_roi.h),
+        (0, 165, 255),
+        2,
+    )
+    shown_value = value if value else "未検出"
+    label = f"値:{shown_value} / 信頼度:{confidence:.2f}"
+    text_pos = (digit_roi.x, max(0, digit_roi.y - 5))
+    cv2.putText(
+        annotated,
+        label,
+        text_pos,
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.6,
+        (0, 0, 255),
+        2,
+        cv2.LINE_AA,
+    )
+    cv2.imwrite(str(output_path), annotated)
+
+
+# --------------------------- ROI Calibration Logic ---------------------------
+
+
+def calibrate_roi_from_frames(
+    frames: Sequence[np.ndarray],
+    template: Optional[np.ndarray],
+    left_margin: float,
+    right_extension: float,
+    top_margin: float,
+    bottom_extension: float,
+    digit_width_factor: float,
+) -> Tuple[ROI, np.ndarray]:
+    """Estimate ROI via template matching against the '×' symbol."""
+
+    if not frames:
+        raise ValueError("No frames available for ROI calibration")
+
+    h, w = frames[0].shape[:2]
+    if template is None:
+        base_size = max(30, min(h, w) // 12)
+        template = build_cross_template(size=base_size)
+
+    scores: List[Tuple[float, Tuple[int, int], int]] = []
+    for idx, frame in enumerate(frames):
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        search = cv2.Canny(gray, 50, 150)
+        tmpl = template
+        if tmpl.ndim == 3:
+            tmpl_gray = cv2.cvtColor(tmpl, cv2.COLOR_BGR2GRAY)
+        else:
+            tmpl_gray = tmpl
+        tmpl_edges = cv2.Canny(tmpl_gray, 50, 150)
+        res = cv2.matchTemplate(search, tmpl_edges, cv2.TM_CCOEFF_NORMED)
+        _, max_val, _, max_loc = cv2.minMaxLoc(res)
+        scores.append((float(max_val), (int(max_loc[0]), int(max_loc[1])), idx))
+
+    scores.sort(key=lambda x: x[0], reverse=True)
+    if not scores:
+        raise RuntimeError("Template matching failed during calibration")
+
+    top_k = scores[: min(5, len(scores))]
+    total_score = sum(score for score, _loc, _idx in top_k)
+    if total_score <= 1e-6:
+        raise RuntimeError("Template matching scores too small; calibration failed")
+
+    weighted_x = sum(score * loc[0] for score, loc, _idx in top_k) / total_score
+    weighted_y = sum(score * loc[1] for score, loc, _idx in top_k) / total_score
+    best_w = template.shape[1]
+    best_h = template.shape[0]
+    roi_x = int(max(0, weighted_x - best_w * left_margin))
+    roi_y = int(max(0, weighted_y - best_h * top_margin))
+    roi_w = int(min(w - roi_x, best_w * (1.0 + right_extension + digit_width_factor)))
+    roi_h = int(min(h - roi_y, best_h * (1.0 + bottom_extension)))
+
+    roi = ROI(roi_x, roi_y, max(1, roi_w), max(1, roi_h))
+
+    # Build refined template from the best-scoring frame
+    best_score, best_loc, best_idx = top_k[0]
+    best_frame = frames[min(max(best_idx, 0), len(frames) - 1)]
+    refined_x = int(best_loc[0])
+    refined_y = int(best_loc[1])
+    refined_w = int(min(best_w, w - refined_x))
+    refined_h = int(min(best_h, h - refined_y))
+    refined_crop = best_frame[refined_y : refined_y + refined_h, refined_x : refined_x + refined_w]
+    refined_template = cv2.cvtColor(refined_crop, cv2.COLOR_BGR2GRAY)
+    return roi.clamp(w, h), refined_template
+
+
+def track_cross(
+    gray_frame: np.ndarray,
+    prev_roi: ROI,
+    template: np.ndarray,
+    search_radius: int,
+    score_threshold: float = 0.35,
+) -> Optional[Tuple[int, int, float]]:
+    h, w = gray_frame.shape[:2]
+    tmpl_h, tmpl_w = template.shape[:2]
+    roi_x = max(0, prev_roi.x - search_radius)
+    roi_y = max(0, prev_roi.y - search_radius)
+    roi_w = min(prev_roi.w + 2 * search_radius, w - roi_x)
+    roi_h = min(prev_roi.h + 2 * search_radius, h - roi_y)
+    search = gray_frame[roi_y : roi_y + roi_h, roi_x : roi_x + roi_w]
+    if search.size == 0 or roi_w < tmpl_w or roi_h < tmpl_h:
+        return None
+    res = cv2.matchTemplate(search, template, cv2.TM_CCOEFF_NORMED)
+    _, max_val, _, max_loc = cv2.minMaxLoc(res)
+    if float(max_val) < score_threshold:
+        return None
+    new_x = roi_x + int(max_loc[0])
+    new_y = roi_y + int(max_loc[1])
+    return new_x, new_y, float(max_val)
+
+
+# ----------------------------- Processing Pipeline ---------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Read multiplier digits from video frames")
+    parser.add_argument("--video", type=str, default="/mnt/data/ズーム動画.mp4", help="Path to input video")
+    parser.add_argument("--frames-dir", type=str, default="", help="Directory of pre-extracted frames (optional)")
+    parser.add_argument("--fps", type=float, default=5.0, help="Sampling FPS")
+    parser.add_argument(
+        "--roi",
+        nargs=4,
+        type=int,
+        metavar=("X", "Y", "W", "H"),
+        help=(
+            "Manual ROI in pixels. Provide the top-left coordinate of the × symbol (X,Y) and set"
+            " W,H so the rectangle encloses the × and the digits immediately to the right."
+        ),
+    )
+    parser.add_argument("--auto-roi", action="store_true", help="Enable automatic ROI calibration from initial frames")
+    parser.add_argument("--calibration-frames", type=int, default=20, help="Number of frames to use for auto ROI calibration")
+    parser.add_argument("--calibration-stride", type=int, default=2, help="Stride between frames during calibration")
+    parser.add_argument("--cross-template", type=str, default="", help="Optional template image for × symbol")
+    parser.add_argument("--track", action="store_true", help="Enable small-window tracking of ROI per frame")
+    parser.add_argument("--drift-radius", type=int, default=12, help="Tracking search radius in pixels")
+    parser.add_argument("--save-annotated", action="store_true", help="Save annotated frames to out_frames directory")
+    parser.add_argument("--output-dir", type=str, default="out_frames", help="Directory for annotated frames")
+    parser.add_argument("--csv", type=str, default="results.csv", help="Output CSV path")
+    parser.add_argument("--digit-band-start", type=float, default=0.35, help="Fractional start (0-1) of digit band within ROI width")
+    parser.add_argument("--digit-band-end", type=float, default=1.0, help="Fractional end (0-1) of digit band within ROI width")
+    parser.add_argument("--cross-band", type=float, default=0.3, help="Fractional width of cross area inside ROI")
+    parser.add_argument(
+        "--digit-offset",
+        type=int,
+        default=4,
+        help="Pixel offset applied to the right edge of the × region before OCR starts (guards against × being read)",
+    )
+    parser.add_argument(
+        "--min-digit-width",
+        type=int,
+        default=56,
+        help="Minimum width in pixels reserved for the digit band (ensures room for up to two digits)",
+    )
+    parser.add_argument("--smooth-window", type=int, default=5, help="Window size for mode voting smoother")
+    parser.add_argument("--ocr-engine", type=str, default="auto", choices=["auto", "paddle", "easyocr", "tesseract"], help="OCR engine selection")
+    parser.add_argument("--ocr-gpu", action="store_true", help="Allow GPU usage for OCR if supported")
+    parser.add_argument("--adaptive-threshold", action="store_true", help="Use adaptive threshold instead of Otsu")
+    parser.add_argument("--digit-regex", type=str, default=r"^[0-9]{1,2}$", help="Regex to validate OCR outputs")
+    parser.add_argument("--clahe-clip", type=float, default=2.0, help="CLAHE clip limit")
+    parser.add_argument(
+        "--clahe-grid",
+        nargs=2,
+        type=int,
+        default=(8, 8),
+        metavar=("GRID_W", "GRID_H"),
+        help="CLAHE grid size (tile width and height)",
+    )
+    parser.add_argument("--scale", type=float, default=2.5, help="Scale factor prior to OCR")
+    parser.add_argument("--summary", action="store_true", help="Print extended summary at end")
+    parser.add_argument(
+        "--digit-color",
+        nargs=3,
+        type=int,
+        metavar=("B", "G", "R"),
+        help="Optional BGR color hint for digits (improves masking when digits have fixed color)",
+    )
+    parser.add_argument(
+        "--color-tolerance",
+        type=int,
+        default=35,
+        help="Tolerance for color-based masking when --digit-color is set",
+    )
+    return parser.parse_args()
+
+
+@dataclass
+class FrameRecord:
+    timestamp: float
+    frame_index: int
+    value: str
+    confidence: float
+    bbox: ROI
+    annotated_name: str = ""
+
+
+def load_template_image(path: str) -> np.ndarray:
+    template = cv2.imread(path, cv2.IMREAD_GRAYSCALE)
+    if template is None:
+        raise FileNotFoundError(f"Failed to read template image: {path}")
+    return template
+
+
+def compute_digit_roi(
+    base_roi: ROI,
+    width: int,
+    height: int,
+    start_frac: float,
+    end_frac: float,
+    min_start: float = 0.0,
+    offset_px: int = 0,
+    min_width_px: int = 1,
+) -> ROI:
+    start_frac = float(np.clip(start_frac, 0.0, 1.0))
+    end_frac = float(np.clip(end_frac, 0.0, 1.0))
+    min_start = float(np.clip(min_start, 0.0, 1.0))
+    offset_px = max(0, int(offset_px))
+    min_width_px = max(1, int(min_width_px))
+
+    if start_frac < min_start:
+        start_frac = min_start
+    if end_frac <= start_frac:
+        end_frac = min(1.0, start_frac + 0.5)
+
+    cross_right = base_roi.x + int(round(base_roi.w * min_start))
+    x_from_frac = base_roi.x + int(round(base_roi.w * start_frac))
+    x = max(x_from_frac, cross_right + offset_px)
+    x = min(x, width - 1)
+    max_x_candidate = base_roi.x + int(round(base_roi.w * end_frac))
+    max_x_candidate = max(max_x_candidate, x + min_width_px)
+    max_x = min(max_x_candidate, width)
+    w = max(1, max_x - x)
+    return ROI(x, base_roi.y, w, base_roi.h).clamp(width, height)
+
+
+def main() -> None:
+    args = parse_args()
+
+    output_dir = Path(args.output_dir)
+    if args.save_annotated:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    ocr_engine = initialize_ocr_engine(args.ocr_engine, allow_gpu=args.ocr_gpu)
+    print(f"Using OCR engine: {ocr_engine.name}")
+    if args.ocr_gpu and ocr_engine.name in {"tesseract", "easyocr"}:
+        print(
+            "Note: GPU acceleration is not used by the selected OCR engine; the --ocr-gpu flag is ignored."
+        )
+
+    frames_for_calibration: List[np.ndarray] = []
+    calibration_template: Optional[np.ndarray] = None
+    if args.cross_template:
+        calibration_template = load_template_image(args.cross_template)
+
+    manual_roi: Optional[ROI] = None
+    if args.roi:
+        manual_roi = ROI(*args.roi)
+        print(
+            "Manual ROI interpreted as: top-left at (X,Y) covering width W and height H around the ×,"
+            " with the OCR digit band taken from {:.0f}% to {:.0f}% of that width toward the right.".format(
+                args.digit_band_start * 100.0,
+                args.digit_band_end * 100.0,
+            )
+        )
+        print(
+            "    ┌─────────── digit band ───────────┐\n"
+            "    │    × area    │     digits      → │\n"
+            "    └──────────────────────────────────┘\n"
+            "    ↑(X,Y)        ↑ ROI width covers both regions"
+        )
+        print(
+            "ヒント: X,Y はフレーム内の × マーク左上に合わせ、W は × と右隣の数字が十分入る幅、"
+            "H は上下の余裕をもたせる高さに設定してください。"
+        )
+        print(
+            "      → スクリプトは ROI の右側帯域だけを切り出して倍率 (数字) を読み取ります。× の右端から"
+            f" {args.digit_offset}px 以上離れた位置から OCR を開始し、{args.min_digit_width}px 分の幅を必ず確保します。"
+        )
+
+    video_path = args.video
+    frames_dir = args.frames_dir
+
+    all_records: List[FrameRecord] = []
+    smoother = ValueSmoother(window_size=args.smooth_window)
+    calibrated_roi: Optional[ROI] = manual_roi
+    clahe_grid = tuple(int(v) for v in args.clahe_grid)
+    digit_color = tuple(int(v) for v in args.digit_color) if args.digit_color else None
+
+    if frames_dir:
+        frame_paths = sorted(
+            [p for p in Path(frames_dir).glob("*") if p.suffix.lower() in {".png", ".jpg", ".jpeg", ".bmp"}],
+            key=lambda p: p.name,
+        )
+        if not frame_paths:
+            raise FileNotFoundError(f"No image frames found in directory: {frames_dir}")
+
+        height = width = None
+        roi = manual_roi
+        cross_template = calibration_template
+        if args.auto_roi and roi is None:
+            for idx, path in enumerate(frame_paths[: args.calibration_frames]):
+                img = cv2.imread(str(path))
+                if img is None:
+                    continue
+                frames_for_calibration.append(img)
+            if not frames_for_calibration:
+                raise RuntimeError("Unable to load frames for calibration")
+            roi, cross_template = calibrate_roi_from_frames(
+                frames_for_calibration,
+                calibration_template,
+                left_margin=0.15,
+                right_extension=0.2,
+                top_margin=0.1,
+                bottom_extension=0.3,
+                digit_width_factor=1.7,
+            )
+        elif roi is None:
+            raise ValueError("ROI must be provided when not using auto calibration")
+
+        cross_band_width = None
+
+        for idx, path in enumerate(frame_paths):
+            frame = cv2.imread(str(path))
+            if frame is None:
+                continue
+            if height is None or width is None:
+                height, width = frame.shape[:2]
+                roi = roi.clamp(width, height)  # type: ignore
+                cross_band_width = max(1, int(roi.w * args.cross_band))
+                if cross_template is None and args.track:
+                    gray_first = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+                    cross_template = gray_first[
+                        roi.y : roi.y + roi.h,
+                        roi.x : roi.x + cross_band_width,
+                    ].copy()
+            frame_index = idx
+            timestamp = idx / args.fps if args.fps > 0 else float(idx)
+            gray_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+
+            if args.track and cross_template is not None and cross_template.size > 0 and cross_band_width:
+                tracked = track_cross(gray_frame, roi, cross_template, args.drift_radius)
+                if tracked is not None:
+                    new_x, new_y, score = tracked
+                    roi = ROI(new_x, new_y, roi.w, roi.h).clamp(width, height)
+                    if score > 0.6:
+                        cross_template = gray_frame[
+                            roi.y : roi.y + roi.h,
+                            roi.x : roi.x + cross_band_width,
+                        ].copy()
+
+            digit_roi_base = compute_digit_roi(
+                roi,
+                width,
+                height,
+                args.digit_band_start,
+                args.digit_band_end,
+                min_start=args.cross_band,
+                offset_px=args.digit_offset,
+                min_width_px=args.min_digit_width,
+            )
+            digit_roi, digit_mask = refine_digit_roi(
+                frame,
+                digit_roi_base,
+                clahe_clip=args.clahe_clip,
+                clahe_grid=clahe_grid,
+                adaptive=args.adaptive_threshold,
+                color_hint=digit_color,
+                color_tolerance=args.color_tolerance,
+                min_x=digit_roi_base.x,
+            )
+            digit_crop = frame[digit_roi.y : digit_roi.y + digit_roi.h, digit_roi.x : digit_roi.x + digit_roi.w]
+            processed = preprocess_for_ocr(
+                digit_crop,
+                scale_factor=args.scale,
+                clahe_clip=args.clahe_clip,
+                clahe_grid=clahe_grid,
+                adaptive=args.adaptive_threshold,
+            )
+            ocr_ready = processed if ocr_engine.name == "tesseract" else cv2.cvtColor(processed, cv2.COLOR_GRAY2BGR)
+            recognitions = ocr_engine.recognize(ocr_ready)
+            value_raw, conf = extract_numeric_candidate(recognitions, whitelist_regex=args.digit_regex)
+            value_raw = disambiguate_three_eight(value_raw, digit_mask)
+            value = smoother.update(value_raw)
+
+            image_name = f"frame_{frame_index:06d}.png"
+            record = FrameRecord(
+                timestamp=timestamp,
+                frame_index=frame_index,
+                value=value,
+                confidence=conf,
+                bbox=digit_roi,
+                annotated_name=image_name if args.save_annotated else "",
+            )
+            all_records.append(record)
+
+            if args.save_annotated:
+                out_path = output_dir / image_name
+                annotate_frame(frame, roi, digit_roi, value, conf, out_path)
+
+        calibrated_roi = roi if args.auto_roi else manual_roi
+
+    else:
+        cap = cv2.VideoCapture(video_path)
+        if not cap.isOpened():
+            raise FileNotFoundError(f"Cannot open video: {video_path}")
+
+        video_fps = cap.get(cv2.CAP_PROP_FPS)
+        if video_fps <= 1e-3:
+            video_fps = args.fps if args.fps > 0 else 30.0
+        frame_interval = max(1, int(round(video_fps / args.fps))) if args.fps > 0 else 1
+
+        frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT)) if cap.get(cv2.CAP_PROP_FRAME_COUNT) > 0 else -1
+        width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)) or None
+        height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)) or None
+
+        # Auto calibration
+        roi = manual_roi
+        cross_template = calibration_template
+        if args.auto_roi and roi is None:
+            cap_calib = cv2.VideoCapture(video_path)
+            if not cap_calib.isOpened():
+                raise FileNotFoundError(f"Cannot open video for calibration: {video_path}")
+            calib_idx = 0
+            while calib_idx < args.calibration_frames:
+                ret, frame = cap_calib.read()
+                if not ret:
+                    break
+                if calib_idx % max(1, args.calibration_stride) == 0:
+                    frames_for_calibration.append(frame.copy())
+                calib_idx += 1
+            cap_calib.release()
+            if not frames_for_calibration:
+                raise RuntimeError("Failed to gather frames for ROI calibration")
+            roi, cross_template = calibrate_roi_from_frames(
+                frames_for_calibration,
+                calibration_template,
+                left_margin=0.15,
+                right_extension=0.25,
+                top_margin=0.1,
+                bottom_extension=0.3,
+                digit_width_factor=1.8,
+            )
+        elif roi is None:
+            raise ValueError("ROI must be provided when not using auto calibration")
+
+        calibrated_roi = roi
+        frame_idx = 0
+
+        cross_band_width = max(1, int(roi.w * args.cross_band))
+        cross_template_ready = cross_template
+
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+
+            timestamp = frame_idx / video_fps if video_fps > 0 else frame_idx
+            if frame_idx % frame_interval != 0:
+                frame_idx += 1
+                continue
+
+            if height is None or width is None:
+                height, width = frame.shape[:2]
+                roi = roi.clamp(width, height)  # type: ignore
+
+            gray_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+
+            if args.track:
+                if cross_template_ready is None or cross_template_ready.size == 0:
+                    cross_crop = gray_frame[roi.y : roi.y + roi.h, roi.x : roi.x + cross_band_width]
+                    cross_template_ready = cross_crop.copy()
+                else:
+                    tracked = track_cross(gray_frame, roi, cross_template_ready, args.drift_radius)
+                    if tracked is not None:
+                        new_x, new_y, score = tracked
+                        roi = ROI(new_x, new_y, roi.w, roi.h).clamp(width, height)
+                        if score > 0.6:
+                            cross_template_ready = gray_frame[
+                                roi.y : roi.y + roi.h,
+                                roi.x : roi.x + cross_band_width,
+                            ].copy()
+
+            digit_roi_base = compute_digit_roi(
+                roi,
+                width,
+                height,
+                args.digit_band_start,
+                args.digit_band_end,
+                min_start=args.cross_band,
+                offset_px=args.digit_offset,
+                min_width_px=args.min_digit_width,
+            )
+            digit_roi, digit_mask = refine_digit_roi(
+                frame,
+                digit_roi_base,
+                clahe_clip=args.clahe_clip,
+                clahe_grid=clahe_grid,
+                adaptive=args.adaptive_threshold,
+                color_hint=digit_color,
+                color_tolerance=args.color_tolerance,
+                min_x=digit_roi_base.x,
+            )
+            digit_crop = frame[digit_roi.y : digit_roi.y + digit_roi.h, digit_roi.x : digit_roi.x + digit_roi.w]
+            processed = preprocess_for_ocr(
+                digit_crop,
+                scale_factor=args.scale,
+                clahe_clip=args.clahe_clip,
+                clahe_grid=clahe_grid,
+                adaptive=args.adaptive_threshold,
+            )
+            ocr_ready = processed if ocr_engine.name == "tesseract" else cv2.cvtColor(processed, cv2.COLOR_GRAY2BGR)
+            recognitions = ocr_engine.recognize(ocr_ready)
+            value_raw, conf = extract_numeric_candidate(recognitions, whitelist_regex=args.digit_regex)
+            value_raw = disambiguate_three_eight(value_raw, digit_mask)
+            value = smoother.update(value_raw)
+
+            image_name = f"frame_{frame_idx:06d}.png"
+            record = FrameRecord(
+                timestamp=timestamp,
+                frame_index=frame_idx,
+                value=value,
+                confidence=conf,
+                bbox=digit_roi,
+                annotated_name=image_name if args.save_annotated else "",
+            )
+            all_records.append(record)
+
+            if args.save_annotated:
+                out_path = output_dir / image_name
+                annotate_frame(frame, roi, digit_roi, value, conf, out_path)
+            frame_idx += 1
+
+        cap.release()
+
+    # ---------------------------- Output Generation ----------------------------
+
+    csv_path = Path(args.csv)
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+
+    mode_comment = "auto_roi" if args.auto_roi else "manual_roi"
+    calibrated_roi_tuple = calibrated_roi.to_tuple() if calibrated_roi else None
+
+    with csv_path.open("w", newline="") as f:
+        f.write(f"# mode: {mode_comment}\n")
+        if calibrated_roi_tuple:
+            f.write(
+                "# calibrated_roi: {0},{1},{2},{3}\n".format(
+                    calibrated_roi_tuple[0],
+                    calibrated_roi_tuple[1],
+                    calibrated_roi_tuple[2],
+                    calibrated_roi_tuple[3],
+                )
+            )
+        if args.save_annotated:
+            f.write(
+                "# annotated_frame_pattern: frame_{frame_index:06d}.png (matches frame_index column when annotations saved)\n"
+            )
+        f.write(
+            "# columns: timestamp_sec(seconds from start), frame_index(zero-based), value(OCR result), "
+            "confidence(0-1 score), bbox_x/bbox_y/bbox_w/bbox_h(pixel ROI of digits), "
+            "annotated_image(saved filename or blank)\n"
+        )
+        f.write("timestamp_sec,frame_index,value,confidence,bbox_x,bbox_y,bbox_w,bbox_h,annotated_image\n")
+        writer = csv.writer(f)
+        for record in all_records:
+            writer.writerow(
+                [
+                    f"{record.timestamp:.3f}",
+                    record.frame_index,
+                    record.value,
+                    f"{record.confidence:.4f}",
+                    record.bbox.x,
+                    record.bbox.y,
+                    record.bbox.w,
+                    record.bbox.h,
+                    record.annotated_name,
+                ]
+            )
+
+    # ------------------------------ Summary Print -----------------------------
+
+    detections = [rec for rec in all_records if rec.value]
+    detection_count = len(detections)
+    avg_conf = sum(rec.confidence for rec in detections) / detection_count if detection_count else 0.0
+    missing_count = len(all_records) - detection_count
+    print("Processed frames:", len(all_records))
+    print("Detected values:", detection_count)
+    print("Average confidence:", f"{avg_conf:.3f}")
+    print("Missing detections:", missing_count)
+    print(f"CSV saved to: {csv_path}")
+    if args.save_annotated:
+        print(f"Annotated frames saved to: {output_dir}")
+        print("  → ファイル名は frame_{frame_index:06d}.png 形式で、results.csv の frame_index 列と対応します。")
+        print("  → 黄色枠は × を含む全体の ROI、オレンジ枠は数字領域、ラベルは『値:● / 信頼度:●』です。")
+
+    if args.summary:
+        unique_values = sorted(set(rec.value for rec in all_records if rec.value))
+        print("Unique detected values:", unique_values)
+        if all_records:
+            first = all_records[0]
+            last = all_records[-1]
+            duration = last.timestamp - first.timestamp if last.timestamp >= first.timestamp else 0.0
+            print(f"Duration covered: {duration:.2f} sec")
+        print("results.csv columns:")
+        print("  timestamp_sec - Seconds from start of the video/frame sequence.")
+        print("      → 処理開始からの経過秒数。")
+        print("  frame_index   - Zero-based index of the processed frame.")
+        print("      → 0 始まりのフレーム番号。")
+        print("  value         - Final stabilized digit string (empty if OCR failed).")
+        print("      → 平滑化後の最終的な認識値（失敗時は空文字）。")
+        print("  confidence    - Confidence score reported by the OCR engine (0-1 range).")
+        print("      → OCR エンジンが返す信頼度 (0〜1)。")
+        print("  bbox_x/y/w/h  - Location and size of the digit crop within the full frame in pixels.")
+        print("      → 元フレーム内での数字領域の位置と大きさ (ピクセル単位)。")
+        print("  annotated_image - Saved filename of the annotated frame (blank when not saved).")
+        print("      → out_frames 内の画像ファイル名。保存していない場合は空欄。")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ensure the digit band always starts a configurable number of pixels to the right of the × glyph and keeps enough width for two digits
- expose `--digit-offset` and `--min-digit-width` options and document the fixed-offset behaviour in the manual ROI guidance
- prevent the refinement mask from shrinking back into the × region by zeroing columns before the enforced offset

## Testing
- python -m compileall read_multiplier.py

------
https://chatgpt.com/codex/tasks/task_b_68d114e3d8d48332bdcbf8f9fc08c1a0